### PR TITLE
New Unit Test (check_linearity - function regarding NaN values in the input df) 

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,2 +1,0 @@
-on:
-  workflow_dispatch:

--- a/tests/unit/test_check_linearity.py
+++ b/tests/unit/test_check_linearity.py
@@ -96,6 +96,29 @@ def test_check_linearity_no_feature_target_correlation(df_example):
     result = check_linearity(df_example_2, target="price", threshold=0.8)
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
+def test_check_linearity_with_missing_values(df_example):
+    """Test handling of missing values in numeric features.
+
+    Ensures that the function does not error when numeric columns
+    contain NaN values and that correlations are still computed
+    using available data.
+    """
+    df_nan = df_example.copy()
+    df_nan.loc[2, "sqft"] = None
+    df_nan.loc[4, "num_rooms"] = None
+
+    result = check_linearity(df_nan, target="price", threshold=0.7)
+
+    # Should still return a valid DataFrame
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty
+
+    # Ensure expected columns exist
+    assert list(result.columns) == ["feature", "correlation"]
+
+    # Ensure correlations are numeric
+    assert result["correlation"].notna().all()
+
 
 def test_check_linearity_tie_break(df_example):
     """Test alphabetical tie-break when multiple features have the same absolute correlation.
@@ -121,6 +144,7 @@ def test_check_linearity_tie_break(df_example):
     assert (
         result["feature"].tolist() == expected_order
     ), "Tie-break alphabetical ordering failed."
+
 
 
 # -------------------------------------

--- a/tests/unit/test_check_linearity.py
+++ b/tests/unit/test_check_linearity.py
@@ -96,6 +96,7 @@ def test_check_linearity_no_feature_target_correlation(df_example):
     result = check_linearity(df_example_2, target="price", threshold=0.8)
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
+
 def test_check_linearity_with_missing_values(df_example):
     """Test handling of missing values in numeric features.
 
@@ -144,7 +145,6 @@ def test_check_linearity_tie_break(df_example):
     assert (
         result["feature"].tolist() == expected_order
     ), "Tie-break alphabetical ordering failed."
-
 
 
 # -------------------------------------


### PR DESCRIPTION
**REMINDER:** Please do NOT merge this PR until after we are happy with all our workflows! When we are ready to merge our new unit functions into main the merge will trigger the workflow - Voila!

- [x] fix #51 
- [x] Write 1 new unit test 
- [x]  test_check_linearity_with_missing_values: test to confirm check_linearity doesn't throw an error when the numeric columns in the input dataframe contain NaN values, and that it still calculates the correlation correctly with all other values. 

We discussed in lab today whether or not this test needs to be in a new file or not. I gave it a thought and my thinking is it makes sense that it could just be in the old file, because that will trigger the workflow just fine - but I've got on my list to ask Daniel in class on Wednesday to be sure! 