### PR TITLE
updated install so installs from docs which includes jupyter

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .
-          pip install "quartodoc<0.7" "griffe<0.37"
+          pip install -e ".[docs]"
 
       - name: Install Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
- [x] fix #99 
- [x] 2nd attempt to fix error in publish-docs workflow - the error message says jupyter is needed, I updated the install command so it installs our docs dependencies from the toml, which includes jupyter! 
- [x] tests added/passed
